### PR TITLE
Bug/Increment the total supply in _unsafeMint

### DIFF
--- a/contracts/token/ERC20/ConfidentialERC20.sol
+++ b/contracts/token/ERC20/ConfidentialERC20.sol
@@ -177,6 +177,7 @@ abstract contract ConfidentialERC20 is IConfidentialERC20, IERC20Errors, TFHEErr
     function _unsafeMintNoEvent(address account, uint64 amount) internal virtual {
         euint64 newBalanceAccount = TFHE.add(_balances[account], amount);
         _balances[account] = newBalanceAccount;
+        _totalSupply += amount;
         TFHE.allowThis(newBalanceAccount);
         TFHE.allow(newBalanceAccount, account);
     }


### PR DESCRIPTION
The `_totalSupply` was not incrementing when new tokens where minted. Fixed it.